### PR TITLE
Update CMD in Dockerfile to use correct path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,4 +11,4 @@ RUN go build -o ./main
 
 EXPOSE 8081
 
-CMD [ "app/main" , "-p=8081"]
+CMD [ "/app/main" , "-p=8081"]


### PR DESCRIPTION
The current `CMD` is `app/main` and `docker run` fails with the following error:
```
/usr/bin/container-entrypoint: line 5: /app/app/main: No such file or directory
```

