### PR TITLE
Handle errors when launching the server

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,20 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
 	"flag"
+	"fmt"
+	"log"
+	"net/http"
 )
+
 var port = flag.Int("p", 8080, "server port")
 
 func main() {
 	flag.Parse()
 	http.HandleFunc("/", HelloServer)
-	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil)
+	if err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil); err != nil {
+		log.Fatal(err.Error())
+	}
 }
 
 func HelloServer(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This fixes golangci-lint error

```
% golangci-lint run ./
main.go:13:21: Error return value of `http.ListenAndServe` is not checked (errcheck)
	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil
```