### PR TITLE
HACDOCS-435: Creating README content for Go code sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# devfile-sample-go-basic
+# Creating an application with a Go code sample
+
+**Note:** The Go code sample uses the **8081** HTTP port.
+
+Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:
+
+* [Go `devfile.yaml`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml)
+* [Go `Dockerfile`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/docker/Dockerfile)
+
+1. The `devfile.yaml` file has an [`image-build` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L20-L27) that points to your `Dockerfile`.
+2. The [`docker/Dockerfile`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/docker/Dockerfile) contains the instructions you need to build the code sample as a container image.
+3. The `devfile.yaml` [`kubernetes-deploy` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L27-L40) points to a `deploy.yaml` file that contains instructions for deploying the built container image.
+4. The `devfile.yaml` [`deploy` command](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L42-L55) completes the [outerloop](https://devfile.io/docs/2.2.0/innerloop-vs-outerloop) deployment phase by pointing to the `image-build` and `kubernetes-deploy` components to create your application.
+
+### Additional resources
+* For more information about Go, see [go.dev](https://go.dev/).
+* For more information about devfiles, see [Devfile.io](https://devfile.io/).
+* For more information about Dockerfiles, see [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).


### PR DESCRIPTION
[HACDOCS-435](https://issues.redhat.com/browse/HACDOCS-435) creating README content for Go code sample.