### PR TITLE
Revert "update the latest static version"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19.9-3
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9-14
 
 COPY . .
 RUN go mod download


### PR DESCRIPTION
Reverts devfile-samples/devfile-sample-go-basic#23

See https://issues.redhat.com/browse/RHTAPBUGS-386 for more details. The current Go Toolset image is failing with:
```
go: no module dependencies to download
STEP 4/7: RUN go build -o ./main
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN go build -o ./main": exit status 1
```

reverting to the previous commit solves the issue. So reverting for now