### PR TITLE
Update: README, Dockerfile, Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Before you begin creating an application with this `devfile` code sample, it's h
 * [Go `devfile.yaml`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml)
 * [Go `Dockerfile`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/docker/Dockerfile)
 
-1. The `devfile.yaml` file has an [`image-build` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L20-L27) that points to your `Dockerfile`.
+1. The `devfile.yaml` file has an [`image-build` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L20-L26) that points to your `Dockerfile`.
 2. The [`docker/Dockerfile`](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/docker/Dockerfile) contains the instructions you need to build the code sample as a container image.
-3. The `devfile.yaml` [`kubernetes-deploy` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L27-L40) points to a `deploy.yaml` file that contains instructions for deploying the built container image.
-4. The `devfile.yaml` [`deploy` command](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L42-L55) completes the [outerloop](https://devfile.io/docs/2.2.0/innerloop-vs-outerloop) deployment phase by pointing to the `image-build` and `kubernetes-deploy` components to create your application.
+3. The `devfile.yaml` [`kubernetes-deploy` component](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L27-L38) points to a `deploy.yaml` file that contains instructions for deploying the built container image.
+4. The `devfile.yaml` [`deploy` command](https://github.com/devfile-samples/devfile-sample-go-basic/blob/main/devfile.yaml#L40-L53) completes the [outerloop](https://devfile.io/docs/2.2.0/innerloop-vs-outerloop) deployment phase by pointing to the `image-build` and `kubernetes-deploy` components to create your application.
 
 ### Additional resources
 * For more information about Go, see [go.dev](https://go.dev/).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9-14
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18
+
+WORKDIR /app
 
 COPY . .
 RUN go mod download
@@ -8,4 +10,4 @@ RUN go build -o ./main
 ENV PORT 8081
 EXPOSE 8081
 
-CMD [ "./main" ]
+CMD [ "/app/main" ]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/devfile-samples/devfile-sample-go-basic
 
-go 1.16
+go 1.18


### PR DESCRIPTION
- Dockerfile to compile src in /app not /
- update go version to same used in build base image
- set base image to 1.18 which always use the latest 1.18 ubi9 image
- README.md correct lines