### PR TITLE
Update go version to 1.19

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.19.13-4.1697647145
 COPY . .
 RUN go mod download
 
-RUN go build -o ./main
+RUN go build -buildvcs=false -o ./main
 
 ENV PORT 8081
 EXPOSE 8081

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9-14
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19.13-4.1697647145
 
 COPY . .
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/devfile-samples/devfile-sample-go-basic
 
-go 1.16
+go 1.19


### PR DESCRIPTION
### What does this PR do?:

This PR follows the update of the default go stack here: https://github.com/devfile/registry/pull/239 

In order to use a supported golang version it updates the dockerfile and the go.mod to use 1.19.
  
### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/1300