### PR TITLE
Enable TLS for version 1

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -29,10 +29,10 @@ apiVersion: v1
 metadata:
   name: my-go-svc
 spec:
-ports:
-  - name: http-8081
-    port: 8081
-    protocol: TCP
-    targetPort: 8081
-selector:
-  app: go-app
+  ports:
+    - name: http-8081
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: go-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -36,6 +36,7 @@ components:
       - name: http-8081
         targetPort: 8081
         path: /
+        secure: true
 commands:
   - id: build-image
     apply:


### PR DESCRIPTION
fixes part of devfile/api#1270

# Changes

- Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled
  - https://devfile.io/docs/2.2.0/devfile-schema#components-kubernetes-endpoints-secure
- Fixes error reported in devfile/api#1390 by providing indentation