### PR TITLE
Enable TLS for version 2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -27,6 +27,7 @@ parent:
       kubernetes:
         uri: kubernetes/deploy.yaml
         endpoints:
-        - name: http-8080
-          targetPort: 8080
-          path: /
+          - name: http-8080
+            targetPort: 8080
+            path: /
+            secure: true


### PR DESCRIPTION
# Description

Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled.

This should enable TLS on OpenShift for this sample when web console has been patched: https://github.com/devfile/api/issues/1270#issuecomment-1866424653

fixes part of devfile/api#1270